### PR TITLE
quote now parses full message links, minor refactor

### DIFF
--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -94,7 +94,7 @@ async def me(ctx, *text : str):
 async def quote(ctx, *, request:str):
     """
     Quotes an existing message from the same channel.
-    request = discord message id (from Copy ID)
+    request = (MessageID|MessageURL)
     (Make sure you have Discord's developer mode turned on to get Message IDs)
     """
 

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -11,6 +11,7 @@ import arrow
 import random
 
 import author_model as author
+from utils import log_msg, block_format, parse_msg_url
 
 # Configure logging
 log = logging.getLogger(__name__)
@@ -24,41 +25,11 @@ streamInstance.setFormatter(fmt)
 log.addHandler(streamInstance)
 log.setLevel(logging.DEBUG)
 
-# Load Frame Data json
-with open('sfv.json', 'r') as f:
-    moves = json.loads(f.read())
+# # Load Frame Data json
+# with open('sfv.json', 'r') as f:
+#     moves = json.loads(f.read())
 
-def log_msg(data):
-    """
-    Accepts a list of data elements, removes the  u'\u241e'character
-    from each element, and then joins the elements using u'\u241e'.
-
-    Messages should be constructed in the format:
-
-        {message_type}\u241e{data}
-
-    where {data} should be a \u241e delimited row.
-    """
-    tmp = [str(d).replace(u'\u241e', ' ') for d in data]
-    return u'\u241e'.join(tmp)
-
-# Format a message as a block quotes.
-def block_format(message):
-
-    # Find new line positions
-    insert_idx = [pos for pos, char in enumerate(message) if char == "\n"]
-    insert_idx.insert(0, -1)
-
-    # Insert "> " for block quote formatting
-    for offset, i in enumerate(insert_idx):
-
-        message = (message[:i + (2 * offset) + 1] + 
-                  "> " + 
-                  message[i + (2 * offset) + 1:])
-
-    return(message)
-
-# Code
+# Bot Code Starts Here
 description = '''
             A Bot to provide Basic Quoting functionality for Discord
             '''
@@ -121,7 +92,11 @@ async def me(ctx, *text : str):
 
 @bot.command(aliases=['q'])
 async def quote(ctx, *, request:str):
-    """Quote an existing message. Make sure you have Discord's developer mode turned on."""
+    """
+    Quotes an existing message from the same channel.
+    request = discord message id (from Copy ID)
+    (Make sure you have Discord's developer mode turned on to get Message IDs)
+    """
 
     log.info(log_msg(['received_request',
                       'quote',
@@ -129,26 +104,41 @@ async def quote(ctx, *, request:str):
                       ctx.message.author.name,
                       ctx.message.author.id]))
 
-    # Parse out message id and reply (if it exists)
-    msg_id = request.split(' ')[0]
+    # Parse out message target and reply (if it exists)
+    msg_target = request.split(' ')[0]
     reply = request.split(' ')[1:]
 
-    if '\r' in msg_id or '\n' in msg_id:
+    if '\r' in msg_target or '\n' in msg_target:
       # If weird users decide to separate the msg_id from the reply using a line return
       # clean it up.
-      if '\r' in msg_id:
-        _temp = msg_id.split('\r')
+      if '\r' in msg_target:
+        _temp = msg_target.split('\r')
       else:
-        _temp = msg_id.split('\n')
+        _temp = msg_target.split('\n')
 
-      msg_id = _temp[0].strip()
+      msg_target = _temp[0].strip()
       reply = [_temp[1].strip()] + request.split(' ')[1:]
 
-    log.info(log_msg(['parsed_request',
-                      'quote',
-                      ctx.message.channel.name,
-                      msg_id,
-                      reply]))
+    # If the Message target is numeric, assume it's the ID
+    # if not assume it's the message url
+    if msg_target.isnumeric():
+        msg_id = msg_target
+
+        log.info(log_msg(['parsed_id_request',
+                        'quote',
+                        ctx.message.channel.name,
+                        msg_id,
+                        reply]))
+    else:
+        _, _, msg_id = parse_msg_url(msg_target)
+
+        log.info(log_msg(['parsed_url_request',
+                        'quote',
+                        ctx.message.channel.name,
+                        msg_target,
+                        msg_id,
+                        reply]))
+
 
     # Clean up request regardless of success
     try:
@@ -274,16 +264,16 @@ async def _format_quote(ctx, msg_):
     output = msg_.content
 
     # Identify the response in the quote without a jump url
-    last_responder = re.search('\*\*(.*)\sresponded:\*\*\s', output)
+    last_responder = re.search(r'\*\*(.*)\sresponded:\*\*\s', output)
 
     current_time = arrow.get(ctx.message.created_at)
 
     # Adjust old relative times
     # First, identify the old times
     old_relative_times = re.findall(
-        '(\*\*.*\[(.*)\]\(\<' +
-        'https:\/\/discordapp\.com\/channels\/[0-9]*\/[0-9]*\/([0-9]*)'
-        +'\>\))',
+        r'(\*\*.*\[(.*)\]\(\<' +
+        r'https:\/\/discordapp\.com\/channels\/[0-9]*\/[0-9]*\/([0-9]*)' +
+        r'\>\))',
         output
     )
 
@@ -350,7 +340,7 @@ async def bot_quote(ctx, msg_, *reply : str):
 
         # Run a regex search for the author name and if you can find it
         # re-attribute. If you can't find it, it'll just be the bot's name
-        _author = re.search("^\*\*(.*)\[(.*)\]\ssaid:\*\*", msg_.clean_content)
+        _author = re.search(r"^\*\*(.*)\[(.*)\]\ssaid:\*\*", msg_.clean_content)
         if _author:
             author = _author.group(1)
             log.info(log_msg(['found_original_author', msg_.id, author]))
@@ -375,7 +365,7 @@ async def bot_quote(ctx, msg_, *reply : str):
         _quoter = re.search("__via.*?__", msg_.content)
         if _quoter:
             # Replace the original quoter with the new quoter
-            output = {0}.replace(
+            output = msg_.content.replace(
                 _quoter.group(0),
                 f"__via {ctx.message.author.name}__"
             )
@@ -387,7 +377,7 @@ async def bot_quote(ctx, msg_, *reply : str):
 
         # Detect Last Response so we can hyperlink
         _last_response = re.search(
-                "\*\*[A-Za-z0-9]*\s(\[[A-Za-z0-9\s]*\])\sresponded",
+                r"\*\*[A-Za-z0-9]*\s(\[[A-Za-z0-9\s]*\])\sresponded",
                 msg_.content
         )
 

--- a/discord_quote/discord_quote/utils.py
+++ b/discord_quote/discord_quote/utils.py
@@ -1,0 +1,47 @@
+import re
+
+def log_msg(data):
+    """
+    Accepts a list of data elements, removes the  u'\u241e'character
+    from each element, and then joins the elements using u'\u241e'.
+
+    Messages should be constructed in the format:
+
+        {message_type}\u241e{data}
+
+    where {data} should be a \u241e delimited row.
+    """
+    tmp = [str(d).replace(u'\u241e', ' ') for d in data]
+    return u'\u241e'.join(tmp)
+
+# Format a message as a block quotes.
+def block_format(message):
+
+    # Find new line positions
+    insert_idx = [pos for pos, char in enumerate(message) if char == "\n"]
+    insert_idx.insert(0, -1)
+
+    # Insert "> " for block quote formatting
+    for offset, i in enumerate(insert_idx):
+
+        message = (message[:i + (2 * offset) + 1] + 
+                  "> " + 
+                  message[i + (2 * offset) + 1:])
+
+    return(message)
+
+def parse_msg_url(url):
+    """
+    Parses out the message id from a discord mesasge url
+    """
+    
+    if not url.startswith('https://discordapp.com/channels/'):
+        raise TypeError("Provided URL is not a Discord Message URL")
+
+    url_template = re.compile(
+        r"https:\/\/discord[a-z]*\.com\/channels\/([0-9]*)\/([0-9]*)\/([0-9]*)"
+    )
+
+    server, channel, message = re.search(url, url_template).groups()
+
+    return server, channel, message

--- a/discord_quote/discord_quote/utils.py
+++ b/discord_quote/discord_quote/utils.py
@@ -36,7 +36,7 @@ def parse_msg_url(url):
     """
     
     if not url.startswith('https://discordapp.com/channels/'):
-        raise TypeError("Provided URL is not a Discord Message URL")
+        raise ValueError("Provided URL is not a Discord Message URL")
 
     url_template = re.compile(
         r"https:\/\/discord[a-z]*\.com\/channels\/([0-9]*)\/([0-9]*)\/([0-9]*)"


### PR DESCRIPTION
The bot is due for some general organizational clean up, but for now i just move a lot of the util fxns out of the main script.

Implemented a very basic message ID extraction in the request parsing, the fxn also returns the server and channel ids in case we want to use those (e.g. for cross channel quoting)

Current the IDs are returned as strings, it doesnt look like we every converted them to numerics before giving them to message retrieval, but may be we should? i dont rmeember