### PR TITLE
feature/cross channel quoting

### DIFF
--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -154,10 +154,10 @@ async def quote(ctx, *, request:str):
 
     try:
         # Retrieve the message
-        msg_ = await ctx.get_channel(channel_id).fetch_message(msg_id)
+        msg_ = await ctx.guild.get_channel(channel_id).fetch_message(msg_id)
         log.info(log_msg(['retrieved_quote',
                       msg_id,
-                      ctx.get_channel(channel_id).name,
+                      ctx.guild.get_channel(channel_id).name,
                       msg_.author.name,
                       msg_.created_at.strftime("%Y-%m-%d %H:%M:%S"),
                       ctx.message.author.name,

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -256,9 +256,16 @@ async def _format_message(ctx, msg_, action):
     original_message_time = arrow.get(msg_.created_at)
     relative_time = original_message_time.humanize(current_time)
 
+    # Construct the channel jump_url
+    channel_url = (
+            f"https://discord.com/channels/"
+        f"{msg_.guild.id}/{msg_.channel.id}"
+    )
+
     output = (
         f"**{msg_.author.name} {action} " +
-        f"[{relative_time}](<{msg_.jump_url}>):**\n"+
+        f"[{relative_time}](<{msg_.jump_url}>) " +
+        f"in [#{msg_.channel.name}](<{channel_url}>):**\n"+
         block_format(msg_.clean_content) + "\n"
     )
 
@@ -582,8 +589,12 @@ async def test(ctx):
     me_cmd = ctx.bot.get_command('me')
     await ctx.invoke(me_cmd, 'is testing the quote-bot.')
 
-    await ctx.channel.send('|---END TESTING QUOTE FUNCTIONS---|')
+    # TEST 11
+    # This test may not work if the bot is not in P4H
+    await ctx.invoke(quote_cmd
+            , request=f'https://discord.com/channels/106536439809859584/202198069691940865/738132703253233735')
 
+    await ctx.channel.send('|---END TESTING QUOTE FUNCTIONS---|')
 
 if __name__=='__main__':
     if os.environ['DISCORD_QUOTEBOT_TOKEN']:

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -34,6 +34,10 @@ description = '''
             A Bot to provide Basic Quoting functionality for Discord
             '''
 
+# Switch for quote notifications; if true, bot will post a notice in the
+# originating channel when quoting across channels.
+quote_notifications = True
+
 bot = commands.Bot(command_prefix='!', description=description)
 
 @bot.event
@@ -183,7 +187,7 @@ async def quote(ctx, *, request:str):
                               ctx.message.channel.name]))
 
             # If cross-channel quoting, inform the originating channel.
-            if ctx.channel.id != channel_id:
+            if ctx.channel.id != channel_id and quote_notifications:
                 # Get or create a webhook for the originating channel
                 hook = await _get_hook(ctx, msg_.channel.id)
 
@@ -210,7 +214,7 @@ async def quote(ctx, *, request:str):
             await bot_quote(ctx, msg_, *reply)
 
             # If cross-channel quoting, inform the originating channel.
-            if ctx.channel.id != channel_id:
+            if ctx.channel.id != channel_id and quote_notifications:
 
                 await ctx.guild.get_channel(msg_.channel.id).send(
                     f"{msg_.author.name} was just quoted in " +

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -130,6 +130,7 @@ async def quote(ctx, *, request:str):
     # if not assume it's the message url
     if msg_target.isnumeric():
         msg_id = msg_target
+        channel_id = ctx.channel.id # if numeric, then channel is same as context
 
         log.info(log_msg(['parsed_id_request',
                         'quote',
@@ -138,7 +139,7 @@ async def quote(ctx, *, request:str):
                         reply]))
     else:
         try:
-            _, _, msg_id = parse_msg_url(msg_target)
+            _, channel_id, msg_id = parse_msg_url(msg_target)
         except ValueError as e:
             log.info(log_msg(['parsed_url_request_failed', msg_target]))
             return
@@ -153,10 +154,10 @@ async def quote(ctx, *, request:str):
 
     try:
         # Retrieve the message
-        msg_ = await ctx.channel.fetch_message(msg_id)
+        msg_ = await ctx.get_channel(channel_id).fetch_message(msg_id)
         log.info(log_msg(['retrieved_quote',
                       msg_id,
-                      ctx.message.channel.name,
+                      ctx.get_channel(channel_id).name,
                       msg_.author.name,
                       msg_.created_at.strftime("%Y-%m-%d %H:%M:%S"),
                       ctx.message.author.name,
@@ -188,7 +189,7 @@ async def quote(ctx, *, request:str):
 
         # Return error if message not found.
         await ctx.channel.send(
-            f"Couldn't quote ({msg_id}) in this channel. " +
+            f"Couldn't quote ({msg_id}) from channel {channel_id}. " +
             f"Requested by {ctx.message.author.name}."
         )
 

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -36,7 +36,7 @@ description = '''
 
 # Switch for quote notifications; if true, bot will post a notice in the
 # originating channel when quoting across channels.
-quote_notifications = True
+quote_notifications = False
 
 bot = commands.Bot(command_prefix='!', description=description)
 

--- a/discord_quote/discord_quote/utils.py
+++ b/discord_quote/discord_quote/utils.py
@@ -44,4 +44,4 @@ def parse_msg_url(url):
 
     server, channel, message = re.search(url_template, url).groups()
 
-    return server, channel, message
+    return int(server), int(channel), int(message)


### PR DESCRIPTION
Related to #61.

1. Underlying changes to the main `quote()` function:
    - `_get_webhook()` is made more general
    - no longer assume all quotes come from the `ctx` channel
2. Added quote notification feature, which needs additional discussion. Perhaps needs to be reverted or edited.