### PR TITLE
Deploy feature/image_quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you want to run a personal version of the bot for testing your own changes, y
 - Navigate to your local repository and set up the development environment using `venv`
     
     ```
-    python3.6 -m venv ./venv
+    python3.7 -m venv ./venv
     . ./venv/bin/activate
     pip install -r ./requirements.txt
     ```
@@ -109,8 +109,21 @@ If you want to run a personal version of the bot for testing your own changes, y
     ```
     
 - At this point, your personal quote bot should show up in #stuff. You'll need to assign appropriate permissions for it to be used in a channel.
+
+### Optional: Use `nodemon` to develop in a fast interactive loop
+
+- To make the process of developing using the personal testing bot smoother, you can monitor `discord_quote.py` for changes and have the command `python discord_quote.py` restarted whenever there is a change to the code:
+- Install `nodemon` (requires `nodejs`)
     
+    ```
+    sudo npm install -g nodemon
+    ```
+- Instead of running `python discord_quote.py`, run
     
+    ```
+    nodemon discord_quote.py
+    ```
+
 # Additional Notes:
 
 - Frame data source from https://github.com/D4RKONION/fatsfvframedatajson

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -558,10 +558,25 @@ async def test(ctx):
             )
     )
 
+    # TEST 6: Quote without a reply, via URL quoting
+    await ctx.invoke(quote_cmd, request=f'{msg_.jump_url}')
+
+    # TEST 7: Quote with a reply, via URL quoting
+    await ctx.invoke(quote_cmd
+            , request=f'{msg_.jump_url} Testing quote + reply functionality (via URL quoting).')
+
+    # TEST 8: Quote a quote without a reply, via URL quoting
+    msg_ = await get_last_message()
+    await ctx.invoke(quote_cmd, request=f'{msg_.jump_url}')
+
+    # TEST 9: Quote a quote with a reply, via URL quoting
+    msg_ = await get_last_message()
+    await ctx.invoke(quote_cmd
+            , request=f'{msg_.jump_url} Testing quoting a quote, with a reply (via URL quoting).')
     # Misquote
     # This seems annoying to test.
 
-    # TEST 6: Me Function
+    # TEST 10: Me Function
     msg_ = await get_last_real_message()
     me_cmd = ctx.bot.get_command('me')
     await ctx.invoke(me_cmd, 'is testing the quote-bot.')

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -175,6 +175,7 @@ async def quote(ctx, *, request:str):
                 content=payload,
                 username=ctx.guild.me.name,
                 avatar_url=str(ctx.guild.me.avatar_url),
+                files=[await attachment.to_file() for attachment in msg_.attachments],
                 wait=True
             )
 

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -34,10 +34,6 @@ description = '''
             A Bot to provide Basic Quoting functionality for Discord
             '''
 
-# Switch for quote notifications; if true, bot will post a notice in the
-# originating channel when quoting across channels.
-quote_notifications = False
-
 bot = commands.Bot(command_prefix='!', description=description)
 
 @bot.event
@@ -186,44 +182,8 @@ async def quote(ctx, *, request:str):
                               'quote',
                               ctx.message.channel.name]))
 
-            # If cross-channel quoting, inform the originating channel.
-            if ctx.channel.id != channel_id and quote_notifications:
-                # Get or create a webhook for the originating channel
-                hook = await _get_hook(ctx, msg_.channel.id)
-
-                channel_url = (
-                    f"https://discord.com/channels/"
-                    f"{msg_.guild.id}/{ctx.channel.id}"
-                )
-
-                await hook.send(
-                    content=(
-                        f"*{msg_.author.name} was just "
-                        f"[quoted](<{out.jump_url}>) in " +
-                        f"[#{ctx.channel.name}](<{channel_url}>).*"
-                    ),
-                    username=ctx.guild.me.name,
-                    avatar_url=str(ctx.guild.me.avatar_url)
-                )
-
-                log.info(log_msg(['sent_webhook_message',
-                                  'quote_notification_webhook',
-                                  ctx.guild.get_channel(channel_id).name]))
-
         else:
             await bot_quote(ctx, msg_, *reply)
-
-            # If cross-channel quoting, inform the originating channel.
-            if ctx.channel.id != channel_id and quote_notifications:
-
-                await ctx.guild.get_channel(msg_.channel.id).send(
-                    f"{msg_.author.name} was just quoted in " +
-                    f"**#{ctx.channel.name}**."
-                )
-
-                log.info(log_msg(['sent_message',
-                         'quote_notification',
-                         ctx.guild.get_channel(channel_id).name]))
 
     except discord.errors.HTTPException as e:
         log.warning(['msg_not_found', msg_id, ctx.message.author.mention, e])

--- a/discord_quote/discord_quote/utils.py
+++ b/discord_quote/discord_quote/utils.py
@@ -44,4 +44,4 @@ def parse_msg_url(url):
 
     server, channel, message = re.search(url_template, url).groups()
 
-    return server, channel, message
+    return int(server), int(channel), int(message)


### PR DESCRIPTION
# Summary of changes 

- Addresses #47
     - When a quoted message has images, we want to be able to see those images in the quote-bot output.
- Additional README documentation for making the development process smoother
